### PR TITLE
tweaked header border so theres no border on the left that overlaps

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
 
   return (
     <>
-      <header className="flex justify-between px-6 py-4 bg-white border-gray-200 border-2 rounded-tr-lg">
+      <header className="flex justify-between px-6 py-4 bg-white border-gray-200 border-b-2 border-r-2 border-t-2 rounded-tr-lg">
         <div>
           <h2 className="text-2xl font-bold">Product management</h2>
           <span className="text-black/70">Manage your store inventory</span>


### PR DESCRIPTION
On the header element theres a border, which i removed the left side from so it doesent overlap with the border thats there from the sidebar